### PR TITLE
Add LetsEncrypt Instruction in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,8 @@ Run a container with the environment variable `VIRTUAL_HOST` set to whatever you
 
 The assistant will forward to the left port (`1337` of `1337:80`) to route via `VIRTUAL_HOST`, or set `VIRTUAL_PORT` to manually configure the forwarded port.
 
+If you need to generate SSL with Let's Encrypt, remember to add `GEN_CERT=true`.
+
 ## Rebuild
 
 `docker-compose build --no-cache`


### PR DESCRIPTION
Looks like here's a way to enable SSL cert. I think it's good to adding it to README.

https://github.com/Xantios/nginx-proxy-manager-assistant/blob/86b6ad52fa438238a2c089400e6be7e244fe980e/app/ContainerEvents.js#L43-L47